### PR TITLE
reordered functions to avoid fork if fix_path doesnt find a match. 

### DIFF
--- a/builtins_1.c
+++ b/builtins_1.c
@@ -96,7 +96,7 @@ int findenvi(char *key, char **envc)
 				break;
 			j++;
 		}
-		if (key[j] == '\0')
+		if (key[j] == '\0' && envc[i][j] == '=')
 			return (i);
 		i++;
 	}

--- a/header_shell.h
+++ b/header_shell.h
@@ -41,7 +41,7 @@ token **create_tokens(char *buffer);
 int count_arguments(char *buffer, char delim, char eol, int *b);
 void free_token(token *t);
 void free_tokens(token **t);
-void fix_path(token *t, char **envp);
+int fix_path(token *t, char **envp);
 int check_builtin(token **ts, int tid, char **buffer, char ***envc);
 char **copy_aos(char ***input, char *add);
 void free_aos(char ***input, int height);

--- a/pathing.c
+++ b/pathing.c
@@ -3,20 +3,24 @@
 * fix_path - checks if command exists in any directory in PATH
 * @t: pointer to token to fix
 * @envc: environment variables array
+*
+* Return: 1 on success, 0 on fail
 */
-void fix_path(token *t, char **envc)
+int fix_path(token *t, char **envc)
 {
 	DIR *d;
 	struct dirent *dir;
 	token *path_token;
-	int i = 0, match_found = 0;
+	int i = 0, match_found = 0, status = 0;
 	char *temp, *path;
 
 	/* grab path value, create path token */
 	path = getenv_value("PATH", envc);
 	if (path == NULL)
-		return;
+		return (0);
 	path_token = create_token(path, ':', '\0', NULL);
+	if (path_token == NULL)
+		return (0);
 	/* loop through all paths in the path token */
 	for (i = 0; path_token->arguments[i]; i++)
 	{
@@ -41,8 +45,9 @@ void fix_path(token *t, char **envc)
 		temp = _strcat(path_token->arguments[i], t->arguments[0], '/');
 		free(t->arguments[0]);
 		t->arguments[0] = temp;
+		status = 1;
 	}
-
 	free_token(path_token);
+	return (status);
 }
 /*For the Glory of PLASTIC CHILDRENS PRODUCTS*/


### PR DESCRIPTION
findenvi now only matches with a key on an EXACT match (PATH no longer == PATH1)